### PR TITLE
meta=eof+json update

### DIFF
--- a/src/http-gateways/trustless-gateway.md
+++ b/src/http-gateways/trustless-gateway.md
@@ -310,22 +310,65 @@ The value of this parameter includes both the location where the metadata is giv
 
 When the location parameter is set to `eof`, which is currently the only supported value, the server SHOULD respond with <Response body as CARv1 stream> <0x00 byte> <Metadata>.
 
-The only supported value for the data type parameter is `json`. This signifies that the metadata MUST be of type `dag-json` (multicodec `0x0129`).
+The only supported value for the data type parameter is `json`. This signifies that the metadata MUST be a JSON object.
 
 This parameter MUST only be used with CAR `version=1`.
 
 When the parameter is not set or does not equal `eof+json`, the server SHOULD not add any extra blocks to the response, neither the 0x00 byte nor any metadata.
 
-When `meta=eof+json`, the dag-json object can include the following keys that SHOULD take values based on their corresponding definiton below.
+When `meta=eof+json`, the JSON object SHOULD conform to the following [JSON schema](https://json-schema.org/).
 
-- `car_bytes`: The total byte length of the CAR stream (excluding the 0x00 byte and the metadata block)
-- `data_bytes`: Total byte length of blocks (excluding the 0x00 byte and the metadata block, but including duplicates when present)
-- `block_count`: Total number of blocks present in the CAR stream (excluding the 0x00 byte and the metadata block, but including duplicates when present)
-- `car_cid`: A hash of the CAR stream giving a CIDv1 with 0x0202 codec
-- `b3checksum`: A Blake3 hash (checksum) of the CAR stream (excluding the 0x00 byte and the metadata block)
-- `content_path`: The url path in the request as executed by the gateway
-- `query_params`: The query string in the request as executed by the gateway
-- `sig`: A signature, using the server's Ed2559 identity, over all other fields returned in the metadata block
+```json
+{
+  "properties": {
+    "description": "Properties of the response"
+    "type": "object"
+  },
+  "error": {
+    "description": "Error message"
+    "type": "string"
+  },
+  "sig": {
+    "description": "A signature, using the server's Ed2559 identity, over the metadata properties object"
+    "type": "string"
+  }
+}
+```
+
+The properties object can include any fields that the server would like to implement. The following properties fields are mentioned explicitly to reach a convention on their definition as they have existing use cases.
+
+```json
+{
+  "car_bytes": {
+    "description": "The total byte length of the CAR stream (excluding the 0x00 byte and the metadata block)",
+    "type": "integer"
+  },
+  "data_bytes": {
+    "description": "Total byte length of blocks (excluding the 0x00 byte and the metadata block, but including duplicates when present)",
+    "type": "integer"
+  },
+  "block_count": {
+    "description": "Total number of blocks present in the CAR stream (excluding the 0x00 byte and the metadata block, but including duplicates when present)",
+    "type": "integer"
+  },
+  "car_cid": {
+    "description": "A hash of the CAR stream giving a CIDv1 with 0x0202 codec",
+    "type": "string"
+  },
+  "b3checksum": {
+    "description": "A Blake3 hash (checksum) of the CAR stream (excluding the 0x00 byte and the metadata block)",
+    "type": "string"
+  },
+  "content_path": {
+    "description": "The url path in the request as executed by the gateway",
+    "type": "string"
+  },
+  "query_params": {
+    "description": "The query string in the request as executed by the gateway",
+    "type": "string"
+  }
+}
+```
 
 ## CAR format parameters and determinism
 

--- a/src/http-gateways/trustless-gateway.md
+++ b/src/http-gateways/trustless-gateway.md
@@ -339,34 +339,64 @@ When `meta=eof+json`, the JSON object SHOULD conform to the following [JSON sche
 }
 ```
 
-The properties object can include any fields that the server would like to implement. The following properties fields are mentioned explicitly to reach a convention on their definition as they have existing use cases.
+The properties object can include any fields that the server would like to implement. The following JSON schema explicitly mentions certain properties fields in order to reach a convention on their definition as they have existing use cases.
 
 ```json
 {
-  "car_bytes": {
-    "description": "The total byte length of the CAR stream (excluding the 0x00 byte and the metadata block)",
-    "type": "integer"
+  "type": "object",
+  "properties": {
+    "car_bytes": {
+      "description": "The total byte length of the CAR stream (excluding the 0x00 byte and the metadata block)",
+      "type": "integer"
+    },
+    "data_bytes": {
+      "description": "Total byte length of the flat file before it was encoded into a CAR file",
+      "type": "integer"
+    },
+    "block_count": {
+      "description": "Total number of blocks present in the CAR stream (excluding the 0x00 byte and the metadata block, but including duplicates when present)",
+      "type": "integer"
+    },
+    "car_cid": {
+      "description": "A hash of the CAR stream giving a CIDv1 with 0x0202 codec",
+      "type": "string"
+    },
+    "b3checksum": {
+      "description": "A Blake3 hash (checksum) of the CAR stream (excluding the 0x00 byte and the metadata block)",
+      "type": "string"
+    },
+    "dag_params": {
+      "description": "A map with DAG params like dag-scope, entity-bytes from [IPIP-402](https://specs.ipfs.tech/ipips/ipip-0402/)",
+      "type": "object",
+      "properties": {
+        "dag-scope": {
+          "description": "See [IPIP-402](https://specs.ipfs.tech/ipips/ipip-0402/) for the definition",
+          "type": "string"
+        },
+        "entity-bytes": {
+          "description": "See [IPIP-402](https://specs.ipfs.tech/ipips/ipip-0402/) for the definition",
+          "type": "string"
+        }
+      },
+      "required": []
+    },
+    "car_params": {
+      "description": "A map with CAR content type params like order and dups from [IPIP-412](https://specs.ipfs.tech/ipips/ipip-0412/)",
+      "type": "object",
+      "properties": {
+        "order": {
+          "description": "See [IPIP-412](https://specs.ipfs.tech/ipips/ipip-0412/) for the definition.",
+          "type": "string"
+        },
+        "dups": {
+          "description": "See [IPIP-412](https://specs.ipfs.tech/ipips/ipip-0412/) for the definition.",
+          "type": "string"
+        }
+      },
+      "required": []
+    }
   },
-  "data_bytes": {
-    "description": "Total byte length of the flat file before it was encoded into a CAR file",
-    "type": "integer"
-  },
-  "block_count": {
-    "description": "Total number of blocks present in the CAR stream (excluding the 0x00 byte and the metadata block, but including duplicates when present)",
-    "type": "integer"
-  },
-  "car_cid": {
-    "description": "A hash of the CAR stream giving a CIDv1 with 0x0202 codec",
-    "type": "string"
-  },
-  "b3checksum": {
-    "description": "A Blake3 hash (checksum) of the CAR stream (excluding the 0x00 byte and the metadata block)",
-    "type": "string"
-  },
-  "retrieval_params": {
-    "description": "Retrieval parameters describing what the client requested from the gateway",
-    "type": "object"
-  }
+  "required": []
 }
 ```
 

--- a/src/http-gateways/trustless-gateway.md
+++ b/src/http-gateways/trustless-gateway.md
@@ -320,17 +320,21 @@ When `meta=eof+json`, the JSON object SHOULD conform to the following [JSON sche
 
 ```json
 {
+  "type": "object",
   "properties": {
-    "description": "Properties of the response"
-    "type": "object"
-  },
-  "error": {
-    "description": "Error message"
-    "type": "string"
-  },
-  "sig": {
-    "description": "A signature, using the server's Ed2559 identity, over the metadata properties object"
-    "type": "string"
+    "data": {
+      "description": "Properties of the response"
+      "type": "object"
+    },
+    "error": {
+      "description": "Error message"
+      "type": "string"
+    },
+    "sig": {
+      "description": "A signature, using the server's Ed2559 identity, over the metadata properties object"
+      "type": "string"
+    },
+    "required": []
   }
 }
 ```

--- a/src/http-gateways/trustless-gateway.md
+++ b/src/http-gateways/trustless-gateway.md
@@ -359,13 +359,9 @@ The properties object can include any fields that the server would like to imple
     "description": "A Blake3 hash (checksum) of the CAR stream (excluding the 0x00 byte and the metadata block)",
     "type": "string"
   },
-  "content_path": {
-    "description": "The url path in the request as executed by the gateway",
-    "type": "string"
-  },
-  "query_params": {
-    "description": "The query string in the request as executed by the gateway",
-    "type": "string"
+  "retrieval_params": {
+    "description": "Retrieval parameters describing what the client requested from the gateway",
+    "type": "object"
   }
 }
 ```

--- a/src/http-gateways/trustless-gateway.md
+++ b/src/http-gateways/trustless-gateway.md
@@ -344,7 +344,7 @@ The properties object can include any fields that the server would like to imple
     "type": "integer"
   },
   "data_bytes": {
-    "description": "Total byte length of blocks (excluding the 0x00 byte and the metadata block, but including duplicates when present)",
+    "description": "Total byte length of the flat file before it was encoded into a CAR file",
     "type": "integer"
   },
   "block_count": {

--- a/src/ipips/ipip-0431.md
+++ b/src/ipips/ipip-0431.md
@@ -52,7 +52,7 @@ The value of this parameter includes both the location where the metadata is giv
 
 When the location parameter is set to `eof`, which is currently the only supported value, the server SHOULD respond with <Response body as CARv1 stream> <0x00 byte> <Metadata>.
 
-The only supported value for the data type parameter is `json`. This signifies that the metadata MUST be of type `dag-json` (multicodec `0x0129`).
+The only supported value for the data type parameter is `json`. This signifies that the metadata MUST be a JSON object.
 
 This parameter MUST only be used with CAR `version=1`.
 
@@ -87,14 +87,6 @@ bytes, which provides a backward-compatible solution for the [CARv1 streaming pr
 {
   "car_bytes": {
     "description": "The total byte length of the CAR stream (excluding the 0x00 byte and the metadata block)",
-    "type": "integer"
-  },
-  "data_bytes": {
-    "description": "Total byte length of blocks (excluding the 0x00 byte and the metadata block, but including duplicates when present)",
-    "type": "integer"
-  },
-  "block_count": {
-    "description": "Total number of blocks present in the CAR stream (excluding the 0x00 byte and the metadata block, but including duplicates when present)",
     "type": "integer"
   },
   "b3checksum": {

--- a/src/ipips/ipip-0431.md
+++ b/src/ipips/ipip-0431.md
@@ -79,14 +79,39 @@ performed the retrieval from the given server.
 - For example, the metadata block could include a `car_bytes` field, the byte length of the CAR stream (excluding the metadata block). This would allow clients to verify whether they received all CAR
 bytes, which provides a backward-compatible solution for the [CARv1 streaming problem](https://github.com/ipfs/specs/pull/332) until new CAR version is introduced.
 
-- As another example, the metadata block could include the `error` field. This would allow the server to pass back additional information about why the response is an error.
+- As another example, the metadata object includes the `error` field, allowing the server to pass back additional information about why the response is an error, such as why the CAR stream was incomplete.
 
-- In the SPARK use case, retrieval clients would like to prove they have retrieved an entire file from a specific retrieval provder that has implemented the trustless gateway spec. The additional metadata block allows custom checksums and signatures to be passed along with the data, allowing the retrieval client to create a proof of correct retrieval. For SPARK, the metadata SHOULD include the following fields:
-  - `car_bytes` - total byte length of the CAR stream (excluding the meta block)
-  - `data_bytes` - total byte length of blocks (excluding the `meta` block, including duplicates when present)
-  - `block_count` - total number of blocks present in the CAR stream (excluding the `meta` block, including duplicates when present)
-  - `b3checksum` - A Blake3 hash (checksum) of the CAR data (excluding the metadata block).
-  - `sig` - A signature over the above fields using server's Ed2559 identity.
+- In the SPARK use case, retrieval clients would like to prove they have retrieved an entire file from a specific retrieval provder that has implemented the trustless gateway spec. The additional metadata block allows checksums and signatures to be passed along with the data, allowing the retrieval client to create a proof of correct retrieval. For SPARK, the metadata properties object SHOULD include the following fields:
+
+```json
+{
+  "car_bytes": {
+    "description": "The total byte length of the CAR stream (excluding the 0x00 byte and the metadata block)",
+    "type": "integer"
+  },
+  "data_bytes": {
+    "description": "Total byte length of blocks (excluding the 0x00 byte and the metadata block, but including duplicates when present)",
+    "type": "integer"
+  },
+  "block_count": {
+    "description": "Total number of blocks present in the CAR stream (excluding the 0x00 byte and the metadata block, but including duplicates when present)",
+    "type": "integer"
+  },
+  "b3checksum": {
+    "description": "A Blake3 hash (checksum) of the CAR stream (excluding the 0x00 byte and the metadata block)",
+    "type": "string"
+  },
+  "content_path": {
+    "description": "The url path in the request as executed by the gateway",
+    "type": "string"
+  },
+  "query_params": {
+    "description": "The query string in the request as executed by the gateway",
+    "type": "string"
+  }
+}
+```
+The metadata `sig` field SHOULD also be populated, returning a signature, using the server's Ed2559 identity, over the metadata properties object.
 
 ### Compatibility
 

--- a/src/ipips/ipip-0431.md
+++ b/src/ipips/ipip-0431.md
@@ -196,7 +196,15 @@ Spend energy on creating CARv3 that solves the problems from "Motivation" sectio
 - native truncation detection and standardized error handling and passing during streaming
 - support for things like [Large Blocks](https://discuss.ipfs.tech/t/supporting-large-ipld-blocks/15093/)
 
-TODO: link to some public  artifact about CARv3
+TODO: link to some public artifact about CARv3
+
+#### Create a new multicodec for this metadata block
+
+Initially, we proposed to create a new multicodec for this metadata block called `car-metadata`. This was ruled out due to some concerns that you can find documented [here](https://github.com/multiformats/multicodec/pull/334#issuecomment-1668086641).
+
+#### Using CBOR instead of JSON for the metadata block
+
+We could use CBOR instead of JSON for the metadata block. However it was [decided](https://github.com/ipfs/specs/pull/431#issuecomment-1719634928) to opt for user readibility over number of bytes since CBOR doesn't greatly reduce the number of bytes in a key value map compared with JSON.
 
 ## Test fixtures
 

--- a/src/ipips/ipip-0431.md
+++ b/src/ipips/ipip-0431.md
@@ -85,21 +85,51 @@ bytes, which provides a backward-compatible solution for the [CARv1 streaming pr
 
 ```json
 {
-  "car_bytes": {
-    "description": "The total byte length of the CAR stream (excluding the 0x00 byte and the metadata block)",
-    "type": "integer"
-  },
-  "b3checksum": {
-    "description": "A Blake3 hash (checksum) of the CAR stream (excluding the 0x00 byte and the metadata block)",
-    "type": "string"
-  },
-  "content_path": {
-    "description": "The url path in the request as executed by the gateway",
-    "type": "string"
-  },
-  "query_params": {
-    "description": "The query string in the request as executed by the gateway",
-    "type": "string"
+  "type": "object",
+  "properties": {
+    "car_bytes": {
+      "description": "The total byte length of the CAR stream (excluding the 0x00 byte and the metadata block)",
+      "type": "integer"
+    },
+    "b3checksum": {
+      "description": "A Blake3 hash (checksum) of the CAR stream (excluding the 0x00 byte and the metadata block)",
+      "type": "string"
+    },
+    "content_path": {
+      "description": "The url path in the request as executed by the gateway",
+      "type": "string"
+    },
+    "dag_params": {
+      "description": "A map with DAG params like dag-scope, entity-bytes from [IPIP-402](https://specs.ipfs.tech/ipips/ipip-0402/)",
+      "type": "object",
+      "properties": {
+        "dag-scope": {
+          "description": "See [IPIP-402](https://specs.ipfs.tech/ipips/ipip-0402/) for the definition",
+          "type": "string"
+        },
+        "entity-bytes": {
+          "description": "See [IPIP-402](https://specs.ipfs.tech/ipips/ipip-0402/) for the definition",
+          "type": "string"
+        }
+      },
+      "required": []
+    },
+    "car_params": {
+      "description": "A map with CAR content type params like order and dups from [IPIP-412](https://specs.ipfs.tech/ipips/ipip-0412/)",
+      "type": "object",
+      "properties": {
+        "order": {
+          "description": "See [IPIP-412](https://specs.ipfs.tech/ipips/ipip-0412/) for the definition.",
+          "type": "string"
+        },
+        "dups": {
+          "description": "See [IPIP-412](https://specs.ipfs.tech/ipips/ipip-0412/) for the definition.",
+          "type": "string"
+        }
+      },
+      "required": []
+    },
+    "required": ["car_bytes", "b3checksum", "content_path", "dag_params", "car_params"]
   }
 }
 ```

--- a/src/ipips/ipip-0431.md
+++ b/src/ipips/ipip-0431.md
@@ -31,7 +31,7 @@ retrieval attestation after the entire response was sent to the client.
 Aside from this specific use case, the IPFS Ecosystem at large has no reliable
 mechanism to signal that a CAR file transmission over HTTP completed successfully.
 
-However, we need this in order to be able to use CARs as a way of serving streaming
+We need this in order to be able to use CARs as a way of serving streaming
 responses for queries. One way of solving this problem is to append an extra block at the end of the
 CAR stream with information that clients can use to check whether all CAR blocks have been received.
 
@@ -46,11 +46,19 @@ HTTP client to opt-in via `Accept` header and Gateway to indicate via
 The proposed solution introduces a new parameter for the CAR content type in HTTP requests
 and responses: `meta`.
 
-When the CAR content type parameter `meta` is set to `eof`, the Gateway will write one additional CAR
-block with metadata to the response, after it sent all CAR blocks.
+The `meta` parameter allows clients to request the server to include additional metadata about the CAR along with the response body.
 
-The metadata format is DAG-CBOR and open to extension, allowing standardized
-userland experimentation similar to the Extensible Data field from IPNS V2.
+The value of this parameter includes both the location where the metadata is given (e.g. `eof`) as well as the type of data received (e.g. `json`) separated by a `+`, to give a value such as `meta=eof+json`
+
+When the location parameter is set to `eof`, which is currently the only supported value, the server SHOULD respond with <Response body as CARv1 stream> <0x00 byte> <Metadata>.
+
+The only supported value for the data type parameter is `json`. This signifies that the metadata MUST be of type `dag-json` (multicodec `0x0129`).
+
+This parameter MUST only be used with CAR `version=1`.
+
+When the parameter is not set or does not equal `eof+json`, the server SHOULD not add any extra blocks to the response, neither the 0x00 byte nor any metadata.
+
+This results in a example content type of `application/vnd.ipld.car;version=1;meta=eof+json`
 
 See [CAR `meta` (content type parameter)](/http-gateways/trustless-gateway/#car-meta-content-type-parameter)
 in Trustless Gateway specification for more details.
@@ -68,8 +76,17 @@ in the future.
 - Clients of trustless gateways can use the fields from the metadata as an attestation that they
 performed the retrieval from the given server.
 
-- The `len` field in the metadata block allows clients to verify whether they received all CAR
+- For example, the metadata block could include a `car_bytes` field, the byte length of the CAR stream (excluding the metadata block). This would allow clients to verify whether they received all CAR
 bytes, which provides a backward-compatible solution for the [CARv1 streaming problem](https://github.com/ipfs/specs/pull/332) until new CAR version is introduced.
+
+- As another example, the metadata block could include the `error` field. This would allow the server to pass back additional information about why the response is an error.
+
+- In the SPARK use case, retrieval clients would like to prove they have retrieved an entire file from a specific retrieval provder that has implemented the trustless gateway spec. The additional metadata block allows custom checksums and signatures to be passed along with the data, allowing the retrieval client to create a proof of correct retrieval. For SPARK, the metadata SHOULD include the following fields:
+  - `car_bytes` - total byte length of the CAR stream (excluding the meta block)
+  - `data_bytes` - total byte length of blocks (excluding the `meta` block, including duplicates when present)
+  - `block_count` - total number of blocks present in the CAR stream (excluding the `meta` block, including duplicates when present)
+  - `b3checksum` - A Blake3 hash (checksum) of the CAR data (excluding the metadata block).
+  - `sig` - A signature over the above fields using server's Ed2559 identity.
 
 ### Compatibility
 


### PR DESCRIPTION
Updated the Trustless Gateway doc and IPIP-431 doc based on the discussion in https://github.com/ipfs/specs/pull/431

Of note, the signature is over all other fields so that it is generic enough for other use cases and can be included in the trustless gateway spec.

There is s till a contentious point about whether b3checksum is generic enough to be included in the top level spec, outside of just the scope of Spark